### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,26 +7,27 @@
 ## further makefiles should be centralized in this file, when
 ## possible.
 
+
 ## Version of the project being built.
 ## Defaults to last git tag.
 VERSION  ?= $(shell git describe --tags --always 2> /dev/null || echo 'development')
+export VERSION
 
 ## List of enabled Stark Build System modules.
 ## The name of the modules are the directories inside 'modules/' directory.
 STARK_BUILD_MODULES ?= meta git golang cloudfunctions docker slack
 
-current_makefile_path = $(abspath $(lastword $(MAKEFILE_LIST)))
+starkbuild_makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+
 # STARK_BUILD_DIR is the directory of this file.
-STARK_BUILD_DIR = $(dir $(current_makefile_path))
+STARK_BUILD_DIR := $(dir $(starkbuild_makefile_path))
 
-main_makefile_path = $(abspath $(firstword $(MAKEFILE_LIST)))
-
+main_makefile_path := $(abspath $(firstword $(MAKEFILE_LIST)))
 # This is the directory of the project includind this makefile.
-PROJECT_DIR = $(dir $(main_makefile_path))
-
+PROJECT_DIR := $(dir $(main_makefile_path))
 
 ## Cache directory where modulos may store temporary files.
-STARK_BUILD_CACHE_DIR ?= .cache
+STARK_BUILD_CACHE_DIR ?= $(PROJECT_DIR)/.cache/
 
 ifeq ($(VERSION),)
 $(error VERSION is empty. Please set VERSION variable)
@@ -36,9 +37,16 @@ ifeq ($(STARK_BUILD_MODULES),)
 $(error STARK_BUILD_MODULES is empty. Please set STARK_BUILD_MODULES variable)
 endif
 
+# Forces uses of bash as the shell. This is important because it defaults to 'sh'
+# but there are differences among the linux distributions. In some 'sh' is an alias
+# do bash (arch linux, for example) and in others 'sh' is an alias to 'dash' (ubuntu).
+SHELL := /bin/bash
+
 $(info [Stark Build] Initializing Stark Build System...)
 $(info [Stark Build]   STARK_BUILD_DIR = $(STARK_BUILD_DIR))
 $(info [Stark Build]   STARK_BUILD_MODULES = $(STARK_BUILD_MODULES))
+$(info [Stark Build]   STARK_BUILD_CACHE_DIR = $(STARK_BUILD_CACHE_DIR))
+$(info [Stark Build]   PROJECT_DIR = $(PROJECT_DIR))
 $(info [Stark Build]   VERSION = $(VERSION))
 
 include $(foreach MOD,$(STARK_BUILD_MODULES),$(STARK_BUILD_DIR)/modules/$(MOD)/Makefile)

--- a/modules/cloudfunctions/Makefile
+++ b/modules/cloudfunctions/Makefile
@@ -69,7 +69,7 @@ cloudfunctions-lint: $(foreach CLOUDFUNCTION,$(CLOUDFUNCTIONS),cloudfunction-lin
 
 cloudfunction-lint-%: cloudfunction-vendor-% ## Run golangci to specific cloud function
 	cd $(CLOUDFUNCTIONS_SRC_DIR)$(@:cloudfunction-lint-%=%) && \
-	$(PROJECT_DIR)$(GOLANGCI) --config $(PROJECT_DIR).golangci.yml run
+	$(GO_TOOLS_DIR)/golangci-lint --config $(PROJECT_DIR).golangci.yml run
 
 # publishing and deploy
 

--- a/modules/golang/install-go-tool.sh
+++ b/modules/golang/install-go-tool.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+toolsdir=${1}
+bin=${2}
+importpath=${3}
+version=${4}
+
+if ! ${bin} -version | grep -qs "${version}"; then
+    echo "Installing $(basename "${bin}") version ${version}"
+    GOBIN=${toolsdir} go install "${importpath}@${version}"
+else
+    echo "$(basename "${bin}") already at version ${version}"
+fi

--- a/modules/slack/Makefile
+++ b/modules/slack/Makefile
@@ -18,9 +18,12 @@ $(info [Stark Build] Initializing slack module...)
 ## Message that will be sent to slack
 SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n/g' -e 's/"/\\"/g')
 
+$(info [Stark Build]   SLACK_MESSAGE = $(SLACK_MESSAGE))
+$(info [Stark Build]   SLACK_WEBHOOK_URL = $(SLACK_WEBHOOK_URL))
+
 ## Posts a message to slack.
-.PHONY: notify-slack
-slack-send-message: require-SLACK_MESSAGE require-REMOTE require-SLACK_WEBHOOK_URL require-VERSION require-PROJECT require-BITBUCKET_BUILD_NUMBER
+.PHONY: slack-send-message
+slack-send-message: require-SLACK_MESSAGE require-SLACK_WEBHOOK_URL
 	GIT_LOG='$(SLACK_GIT_LOG)' \
 		envsubst < $(SLACK_MESSAGE) | \
 		curl \


### PR DESCRIPTION
- Properly exports VERSION variable

The export line was not migrated to the main makefile as it should.

- Fixes STARK_BUILD_DIR variable

It's value would change depending on the fist call to the variable. The
correct way to define this variable is by using the `:=` operator.

- Fixes STARK_CACHE_DIR

It now contains the full path to the cache directory.

- Sets default shell to bash

This solves an issue in which that different distributions uses
different aliases to sh.

- Fixes utilization of golangci-lint
- Fixes installation of golang tools

Tools that could be installed using `go install` now are installed using
an external script.

- Added all tools by default.
- Fixes slack module

Target was renamed to be more semantic and extra variables not used
directly by the target were droped.