### PR TITLE
Adds auto-update target

### DIFF
--- a/modules/meta/Makefile
+++ b/modules/meta/Makefile
@@ -21,14 +21,18 @@ require-%:
 print-%:
 	@ echo "${${*}}"
 
-## Updates Stark Build System.
-.PHONY: update-stark-build
-update-stark-build:
+## Updates the Stark Build System to match what the superproject expects.
+.PHONY: stark-build-sync
+stark-build-sync:
 	git submodule update --init --recursive $(STARK_BUILD_DIR)
+
+## Updates the Stark Build System to the latest version.
+.PHONY: stark-build-update
+stark-build-update:
+	cd $(STARK_BUILD_DIR) && git pull
 
 
 ## Prints this help.
-
 .PHONY: help
 help:
 	@awk -f $(STARK_BUILD_DIR)modules/meta/help.awk $(MAKEFILE_LIST)


### PR DESCRIPTION
Target `update-stark-build` was changed to `stark-build-sync` because it
only synchronizes the stark build directory to what it is expected by the
git submodule in the parent project.

A new target was added `stark-build-update` that actually updates the
stark build directory by running a `git pull` inside stark build
directory.