### PR TITLE
Adds a default slack message

### DIFF
--- a/modules/golang/Makefile
+++ b/modules/golang/Makefile
@@ -32,6 +32,8 @@ GOARCH      ?= amd64
 CGO_ENABLED ?= 0
 GO111MODULE ?= on
 
+export GO_MODULE
+export GO_PROJECT
 export GOOS
 export GOARCH
 export GO111MODULE

--- a/modules/slack/Makefile
+++ b/modules/slack/Makefile
@@ -18,6 +18,15 @@ $(info [Stark Build] Initializing slack module...)
 ## Message that will be sent to slack
 SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n/g' -e 's/"/\\"/g')
 
+## Message in json format that will be posted to Slack.
+## The default value is just a simple message that could be used
+## initially but it's expected that each project will have it's own
+## message.
+## Before the message is sent the json is altered using envsubst
+## so we have minimal templating capabilities.
+## The variable SLACK_GIT_LOG is passed as GIT_LOG to the envsubst.
+SLACK_MESSAGE ?= $(STARK_BUILD_DIR)modules/slack/message.json
+
 $(info [Stark Build]   SLACK_MESSAGE = $(SLACK_MESSAGE))
 $(info [Stark Build]   SLACK_WEBHOOK_URL = $(SLACK_WEBHOOK_URL))
 

--- a/modules/slack/message.json
+++ b/modules/slack/message.json
@@ -1,0 +1,42 @@
+{
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": "New release ready for deploy!",
+        "emoji": true
+      }
+    },
+    {
+      "type": "section",
+      "fields": [
+        {
+          "type": "mrkdwn",
+          "text": "*Project:*\n${GO_PROJECT}"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "*Version:*\n${VERSION}>"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Please monitor the deploy for any bugs or anomalies."
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "```${GIT_LOG}```"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a simple slack message template. The template is very simple and
it's intended as a initial version of the message.

It's expected that people will design their own messages for each
projects.

Links:

- https://github.com/arquivei/stark-build/issues/7