### PR TITLE
Fix swagger file name when publishing

### DIFF
--- a/modules/golang/swagger.mk
+++ b/modules/golang/swagger.mk
@@ -38,4 +38,4 @@ endif
 	$(eval CMD=$(@:go-swagger-publish-%=%))
 	gsutil cp \
 		out/docs/$(CMD).swagger.json \
-		gs://$(GO_SWAGGER_PUBLISH_BUCKET)/$(GO_SWAGGER_PUBLISH_PATH)/$(PROJECT)-$(CMD).json
+		gs://$(GO_SWAGGER_PUBLISH_BUCKET)/$(GO_SWAGGER_PUBLISH_PATH)/$(GO_PROJECT)-$(CMD).json


### PR DESCRIPTION
The swagger publish target was using the wrong variable to compose the
filename and it was generating broken file names.

The target was fixed to use the correct variable (GO_PROJECT) to prefix
the filename.