### PR TITLE
Fix typo in slack message

### DIFF
--- a/modules/slack/message.json
+++ b/modules/slack/message.json
@@ -17,7 +17,7 @@
         },
         {
           "type": "mrkdwn",
-          "text": "*Version:*\n${VERSION}>"
+          "text": "*Version:*\n${VERSION}"
         }
       ]
     },


### PR DESCRIPTION
The version was ending with a `>` character.