### PR TITLE
Fix updating go tools not working

### DIFF
--- a/modules/golang/install-go-tool.sh
+++ b/modules/golang/install-go-tool.sh
@@ -8,7 +8,7 @@ bin=${2}
 importpath=${3}
 version=${4}
 
-if ! ${bin} -version | grep -qs "${version}"; then
+if ! ${bin} -version | grep --quiet --no-messages --fixed-strings "${version}"; then
     echo "Installing $(basename "${bin}") version ${version}"
     GOBIN=${toolsdir} go install "${importpath}@${version}"
 else

--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -41,7 +41,7 @@ go-tools: $(foreach tool,$(GO_TOOLS),$(GO_TOOLS_DIR)/$(tool))
 # See https://goswagger.io/install.html
 .PHONY: $(GO_TOOLS_DIR)/swagger
 $(GO_TOOLS_DIR)/swagger: | $(GO_TOOLS_DIR)
-	@ if ! $@ version | grep -qs "$(GO_SWAGGER_VERSION)"; then \
+	@ if ! $@ version | grep --quiet --no-messages --fixed-strings "$(GO_SWAGGER_VERSION)"; then \
 		echo "Installing $@ version $(GO_TOOLS_SWAGGER_VERSION)"; \
 		curl -o $@ -L'#' "https://github.com/go-swagger/go-swagger/releases/download/$(GO_TOOLS_SWAGGER_VERSION)/swagger_$(GO_TOOLS_OS)_$(GO_TOOLS_ARCH)"; \
 		chmod +x $@; \
@@ -53,7 +53,7 @@ $(GO_TOOLS_DIR)/swagger: | $(GO_TOOLS_DIR)
 # See: https://golangci-lint.run/usage/install/
 .PHONY: $(GO_TOOLS_DIR)/golangci-lint
 $(GO_TOOLS_DIR)/golangci-lint: | $(GO_TOOLS_DIR)
-	@ if ! $@ --version | grep -qs "$(GO_TOOLS_GOLANGCI_VERSION)"; then \
+	@ if ! $@ --version | grep --quiet --no-messages --fixed-strings "$(GO_TOOLS_GOLANGCI_VERSION)"; then \
 		echo "Installing $@ version $(GO_TOOLS_GOLANGCI_VERSION)"; \
 		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 			sh -s -- -b "$(GO_TOOLS_DIR)" "v$(GO_TOOLS_GOLANGCI_VERSION)"; \


### PR DESCRIPTION
In some rare cases, the updating was failing to check that the current
version is not the desired one. This was caused by the grep command and
was processing the query string as a regular expression. So the dots in
the version string were matching any character.

The particular case we found was on golangci-lint. We were trying to
update to version `1.48.0` but is was matching the timestamp `11:48:06`

Example of the golangci-lint version that matches `1.48.0`:

```
golangci-lint has version 1.37.1 built from b39dbcd6 on 2021-02-20T11:48:06Z
```