### PR TITLE
Improves escaping on 'slack-send-message' need ENVs

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -3,6 +3,15 @@
 ## Module: Docker
 ## This module handles docker image creation and publishing.
 
+## Images to be created are listed by DOCKER_IMAGES variable,
+## and defaults to all directories found directly under 'cmd'
+## path.
+##
+## By default, a scratch image (see stark-build/docker/Dockerfile)
+## will be used. If a custom Dockerfile is needed, a Dockerfile
+## can be added (i.e 'cmd/mybinary/Dockerfile'). Then, the provided
+## Dockerfile will be used instead
+
 #
 # TODO: Translate to english
 # Esse módulo permite construir imagens docker e publicá-las.

--- a/modules/slack/Makefile
+++ b/modules/slack/Makefile
@@ -16,7 +16,7 @@ $(info [Stark Build] Initializing slack module...)
 # This can be overwritten by redefining this variable in the main Makefile.
 
 ## Message that will be sent to slack
-SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n/g' -e 's/"/\\"/g')
+SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n/g' -e 's/"/\\\\\\"/g')
 
 ## Message in json format that will be posted to Slack.
 ## The default value is just a simple message that could be used
@@ -33,7 +33,7 @@ $(info [Stark Build]   SLACK_WEBHOOK_URL = $(SLACK_WEBHOOK_URL))
 ## Posts a message to slack.
 .PHONY: slack-send-message
 slack-send-message: require-SLACK_MESSAGE require-SLACK_WEBHOOK_URL
-	GIT_LOG='$(SLACK_GIT_LOG)' \
+	GIT_LOG="$(SLACK_GIT_LOG)" \
 		envsubst < $(SLACK_MESSAGE) | \
 		curl \
 			--header 'Content-type: application/json' \

--- a/modules/slack/Makefile
+++ b/modules/slack/Makefile
@@ -16,7 +16,7 @@ $(info [Stark Build] Initializing slack module...)
 # This can be overwritten by redefining this variable in the main Makefile.
 
 ## Message that will be sent to slack
-SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n/g' -e 's/"/\\\\\\"/g')
+SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n/g' -e 's/"/\\\\\\"/g' -e 's/`/\\`/g' )
 
 ## Message in json format that will be posted to Slack.
 ## The default value is just a simple message that could be used
@@ -37,6 +37,5 @@ slack-send-message: require-SLACK_MESSAGE require-SLACK_WEBHOOK_URL
 		envsubst < $(SLACK_MESSAGE) | \
 		curl \
 			--header 'Content-type: application/json' \
-			--data @- $(SLACK_WEBHOOK_URL)
-
+			--data-binary @- $(SLACK_WEBHOOK_URL)
 $(info [Stark Build] Slack module loaded.)


### PR DESCRIPTION
Problem:

The 'GIT_LOG' variable being created was vulnerable to pieces of commit
messages like this:

 - Let's break the commit (message). "Oh great..." you think.

The problem is that the use of the message within 'slack-send-message'
is wrapping the results with single quotes, which we cannot escape in
command line. When finding the first single quote, the command would
break into default behavior and then emit a syntax error upon finding
the '(' character.

 - syntax error near unexpected token `('

Solution:

Change escaping to use double quotes instead of single quotes. This
change resulted in invalid json to be sent to Slack, which was fixed by
adding a higher level of double quotes escaping when parsing the commit
into 'GIT_LOG'