### PR TITLE
Fix golang building for projects using buildenv.mk

### DIFF
--- a/modules/golang/Makefile
+++ b/modules/golang/Makefile
@@ -79,6 +79,7 @@ GO_LIB_DIR ?= lib
 GO_LIB_OUTPUT_DIR ?= out/lib
 
 $(info [Stark Build] Initializing golang module...)
+$(info [Stark Build]   GOVERSION = $(shell $(GO) env GOVERSION))
 $(info [Stark Build]   GO_BINS = $(GO_BINS))
 $(info [Stark Build]   COMPRESS_ENABLED = $(COMPRESS_ENABLED))
 $(info [Stark Build]   GO_MINIMUM_COVERAGE = $(GO_MINIMUM_COVERAGE))
@@ -91,7 +92,11 @@ out/bin:
 
 ## Compiles all binaries listed in GO_BINS.
 .PHONY: go-bin
-go-bin: $(foreach BIN,$(GO_BINS),out/bin/$(BIN))
+go-bin:
+	@for BIN in $(GO_BINS); do \
+		echo "[Stark Build] Building '$${BIN}'..."; \
+		$(MAKE) "out/bin/$${BIN}"; \
+	done;
 
 # Generic rule for building binaries
 out/bin/%: vendor | out/bin ## Compiles a command under cmd/<command> into out/bin/<command>


### PR DESCRIPTION
There was an issue when building golang binaries that a buildenv.mk was
loaded for one binary, but it was kept loaded when building the next
binary that didn't use a buildenv.mk.

The go-bin target was altered to run make for each target in go-bin.