### PR TITLE
Adds post-merge git hook

### DIFF
--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -11,6 +11,10 @@ $(info [Stark Build] Initializing git module...)
 ## Default: go-tools vendor git-ensure-clean go-lint go-tests go-ensure-coverage
 GIT_HOOKS_PRECOMMIT ?= go-tools vendor git-ensure-clean go-lint go-tests go-ensure-coverage
 
+## List of targets that will run on post-merge
+## Default: vendor
+GIT_HOOKS_POSTMERGE ?= vendor
+
 ## Directory containing the hooks that should be installed.
 ## Default: $(STARK_BUILD_DIR)modules/git/hooks
 GIT_HOOKS_DIR ?= $(STARK_BUILD_DIR)modules/git/hooks
@@ -32,5 +36,9 @@ git-install-hooks: $(GIT_HOOKS_DIR)
 ## Executes pre-commit hook.
 .PHONY: git-execute-hook-precommit
 git-execute-hook-precommit: $(GIT_HOOKS_PRECOMMIT)
+
+## Executes post-merge hook.
+.PHONY: git-execute-hook-postmerge
+git-execute-hook-postmerge: $(GIT_HOOKS_POSTMERGE)
 
 $(info [Stark Build] Git module loaded.)

--- a/modules/git/hooks/post-merge
+++ b/modules/git/hooks/post-merge
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make git-execute-hook-postmerge

--- a/modules/git/hooks/pre-commit
+++ b/modules/git/hooks/pre-commit
@@ -1,5 +1,3 @@
-#!/bin/bash
-
-# To install this hook run: 'make install-hooks' from the project's root directory.
+#!/usr/bin/env bash
 
 make git-execute-hook-precommit


### PR DESCRIPTION
It often occurs that after pulling new code, the go.sum is changed and everything breaks because vendor directory is inconsistent.

Adds a new post merge hook that will call  `make vendor` after a successful merge/pull. This was done following the same architecture as the previous hook, so if can be overwritten by the new variable GIT_HOOKS_POSTMERGE.