### PR TITLE
Adds a more generic docker support

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -8,25 +8,11 @@
 ## path.
 ##
 ## By default, a scratch image (see stark-build/docker/Dockerfile)
-## will be used. If a custom Dockerfile is needed, a Dockerfile
-## can be added (i.e 'cmd/mybinary/Dockerfile'). Then, the provided
-## Dockerfile will be used instead
-
-#
-# TODO: Translate to english
-# Esse módulo permite construir imagens docker e publicá-las.
-# O módulo provê um arquivo `Dockerfile` próprio, porém é possível
-# sobrescrever esse comportamento para binários específicos. Para
-# utilizar um `Dockerfile` próprio, basta criar um `Dockerfile`
-# dentro do diretório `cmd/<binário>`.
-#
-# Por exemplo, suponha 2 binários `api` e `worker` respectivamente
-# em `cmd/api` e `cmd/worker`. Caso exista o arquivo
-# `cmd/api/Dockerfile`, ao ser invocado o comando de construir a
-# imagems, por exemplo, com `docker-images`, a imagem do binaŕio
-# `api` usará `cmd/api/Dockerfile` mas a imagem do binário `worker`
-# usará `<stark-build>/modules/docker/Dockerfile`.
-
+## will be used. If a custom Dockerfile is needed, a Dockerfile must
+## be created under the cmd directory, i.e., 'cmd/mybinary/Dockerfile'.
+## This new Dockerfile will be used automatically.
+##
+## NOTE: Some variables are deprecated. Please update your build.
 
 ## Docker Module Variables
 
@@ -35,22 +21,49 @@
 DOCKER_IMAGES ?= $(shell ls ./cmd/ 2> /dev/null)
 
 ## Name of the project. This will compose the image's name like
-## 'DOCKER_BASE_IMAGE/CMD:VERSION'. It defaults to the projets
-## diretory name.
+## 'gcr.io/<GCR_PROJECT>/<DOCKER_BASE_IMAGE>/<CMD>:<VERSION>'.
+## It defaults to the projets directory name.
+## Deprecated: Use DOCKER_IMAGE_PREFIX instead
 DOCKER_BASE_IMAGE ?= $(GO_PROJECT)
 
-## GCR_BASE_URL is the googles registry prefix that will be
-## pre-appended at the image name.
-## You propably don't want to change this.
-GCR_BASE_URL ?= gcr.io/$(GCR_PROJECT)
+## Google's registry prefix that will be pre-appended at the
+## image name like '<GCR_BASE_URL>/<DOCKER_BASE_IMAGE>/<CMD>:<VERSION>'.
+## Defaults to 'gcr.io/<GCR_PROJECT>'. See GCR_PROJECT.
+## Deprecated: Use DOCKER_IMAGE_PREFIX instead
+GCR_BASE_URL ?=
+
+## Is the project id for the google's container registry. See DOCKER_BASE_IMAGE
+## documentation.
+## Deprecated: Use DOCKER_IMAGE_PREFIX instead
+GCR_PROJECT ?=
+
+ifdef GCR_BASE_URL
+$(info [Stark Build] !!! Setting GCR_BASE_URL is deprecated. Please set DOCKER_IMAGE_PREFIX instead.)
+ifndef DOCKER_BASE_IMAGE
+$(error [Stark Build] Missing required variable DOCKER_BASE_IMAGE)
+endif
+DOCKER_IMAGE_PREFIX ?= $(GCR_BASE_URL)/$(DOCKER_BASE_IMAGE)
+else
+ifdef GCR_PROJECT
+$(info [Stark Build] !!! Setting GCR_PROJECT is deprecated. Please set DOCKER_IMAGE_PREFIX instead.)
+DOCKER_IMAGE_PREFIX ?= gcr.io/$(GCR_PROJECT)/$(DOCKER_BASE_IMAGE)
+else
+## Prefix of the image. This will be used to make the fullname of the
+## image as <DOCKER_IMAGE_PREFIX>/<CMD>:<VERSION>
+## The default value is deprecated and will depends on what variables are set. The order is:
+##   1: $(GCR_BASE_URL)/$(DOCKER_BASE_IMAGE)
+##   2: gcr.io/$(GCR_PROJECT)/$(DOCKER_BASE_IMAGE)
+DOCKER_IMAGE_PREFIX ?=
+endif
+endif
 
 $(info [Stark Build] Initializing docker module...)
 $(info [Stark Build]   DOCKER_IMAGES = $(DOCKER_IMAGES))
-$(info [Stark Build]   DOCKER_BASE_IMAGE = $(DOCKER_BASE_IMAGE))
-$(info [Stark Build]   GCR_PROJECT = $(GCR_PROJECT))
-$(info [Stark Build]   GCR_BASE_URL = $(GCR_BASE_URL))
+$(info [Stark Build]   DOCKER_IMAGE_PREFIX = $(DOCKER_IMAGE_PREFIX))
+$(info [Stark Build]   DOCKER_BASE_IMAGE [Deprecated] = $(DOCKER_BASE_IMAGE))
+$(info [Stark Build]   GCR_PROJECT [Deprecated] = $(GCR_PROJECT))
+$(info [Stark Build]   GCR_BASE_URL [Deprecated] = $(GCR_BASE_URL))
 
-##
 ## Docker Module Targets
 
 ## Builds all images listed in DOCKER_IMAGES var.
@@ -58,21 +71,20 @@ $(info [Stark Build]   GCR_BASE_URL = $(GCR_BASE_URL))
 docker-images: $(foreach img,$(DOCKER_IMAGES),docker-image-$(img))
 
 ## Builds a tar file containing all images
-out/docker_images.tar: docker-images require-DOCKER_BASE_IMAGE
-	docker save --output $@ $(foreach img,$(DOCKER_IMAGES),$(DOCKER_BASE_IMAGE)/$(img):$(VERSION))
+out/docker_images.tar: docker-images require-DOCKER_IMAGE_PREFIX
+	docker save --output $@ $(foreach img,$(DOCKER_IMAGES),$(DOCKER_IMAGE_PREFIX)/$(img):$(VERSION))
 
 ## Builds single docker image
 .PHONY: docker-image-%
-docker-image-%: require-DOCKER_BASE_IMAGE
+docker-image-%: require-DOCKER_IMAGE_PREFIX
 	$(eval BINARY = $(@:docker-image-%=%))
 	$(eval DOCKERFILE = $(shell [ -f cmd/$(BINARY)/Dockerfile ] && echo cmd/$(BINARY)/Dockerfile || echo $(STARK_BUILD_DIR)modules/docker/Dockerfile ) )
 	docker build \
 		--build-arg BINARY=out/bin/$(BINARY) \
 		--file $(DOCKERFILE) \
 		--pull \
-		--tag '$(DOCKER_BASE_IMAGE)/$(BINARY):$(VERSION)' \
+		--tag '$(DOCKER_IMAGE_PREFIX)/$(BINARY):$(VERSION)' \
 		.
-
 
 ## Publishes all docker images using VERSION as tag.
 .PHONY: docker-publish
@@ -83,31 +95,21 @@ docker-publish: $(foreach img,$(DOCKER_IMAGES),docker-publish-version-$(img))
 docker-publish-latest: $(foreach img,$(DOCKER_IMAGES),docker-publish-latest-$(img))
 
 ## Publishes a single image using 'latest' as tag.
-docker-publish-latest-%: require-DOCKER_BASE_IMAGE
-ifndef GCR_PROJECT
-	$(error Please set GCR_PROJECT variable)
-endif
-	$(eval IMAGE = $(@:docker-publish-latest-%=$(DOCKER_BASE_IMAGE)/%))
+docker-publish-latest-%: require-DOCKER_IMAGE_PREFIX require-VERSION
+	$(eval IMAGE = $(@:docker-publish-latest-%=$(DOCKER_IMAGE_PREFIX)/%))
 	$(eval LOCAL_TAG = $(IMAGE):$(VERSION))
-	$(eval REMOTE_TAG = $(GCR_BASE_URL)/$(IMAGE):latest)
+	$(eval REMOTE_TAG = $(IMAGE):latest)
 	docker tag $(LOCAL_TAG) $(REMOTE_TAG)
 	docker push $(REMOTE_TAG)
 
 ## Publishes the generated images into Google's Registry using version as tag.
-docker-publish-version-%: require-DOCKER_BASE_IMAGE
-ifndef GCR_PROJECT
-	$(error Please set GCR_PROJECT variable)
-endif
-	$(eval IMAGE = $(@:docker-publish-version-%=$(DOCKER_BASE_IMAGE)/%))
-	$(eval LOCAL_TAG = $(IMAGE):$(VERSION))
-	$(eval REMOTE_TAG = $(GCR_BASE_URL)/$(LOCAL_TAG))
-	docker tag $(LOCAL_TAG) $(REMOTE_TAG)
-	docker push $(REMOTE_TAG)
-
+docker-publish-version-%: require-DOCKER_IMAGE_PREFIX require-VERSION
+	$(eval IMAGE = $(@:docker-publish-version-%=$(DOCKER_IMAGE_PREFIX)/%))
+	docker push $(IMAGE):$(VERSION)
 
 ## Removes all local images matching the same base name.
 .PHONY: docker-clean
 docker-clean:
-	docker images -a | grep $(DOCKER_BASE_IMAGE) | awk '{print $$3}' | xargs --no-run-if-empty docker rmi
+	docker images -a | grep $(DOCKER_IMAGE_PREFIX) | awk '{print $$3}' | xargs --no-run-if-empty docker rmi
 
 $(info [Stark Build] Docker module initialized.)

--- a/modules/meta/help.awk
+++ b/modules/meta/help.awk
@@ -1,12 +1,12 @@
 {
-    if ($0 ~ /^.PHONY: [a-zA-Z\-_0-9%]+$/) {
+    if ($0 ~ /^.PHONY: [a-zA-Z\-_0-9%/]+$/) {
         helpCommand = substr($0, index($0, ":") + 2);
         if (helpMessage) {
             printf "\033[36m%-20s\033[0m %s\n",
                 helpCommand, helpMessage;
             helpMessage = "";
         }
-    } else if ($0 ~ /^[a-zA-Z\-_0-9.%]+:/) {
+    } else if ($0 ~ /^[a-zA-Z\-_0-9.%/]+:/) {
         helpCommand = substr($0, 0, index($0, ":") - 1);
         if (helpMessage) {
             printf "\033[36m%-20s\033[0m %s\n",


### PR DESCRIPTION
The previous docker module depends heavily on googles container registry. This commit introduces the DOCKER_IMAGE_PREFIX variable that is supposed to replace the previous behavior. Now images are named just as PREFIX/CMD.

Previous behavior can still be achieved by setting the GCP_PROJECT and DOCKER_BASE_IMAGE variables. This is expected to be removed in the future and whoever is calling the make target should set the expected prefix.

This commit also forces the images to always be created with the full name. So new the publish targets are not compatible with old images. This particular case is not supposed to happen and should be considered an error.

Fixed an error in help module that prevented targets with the slash character to be shown.