### PR TITLE
Adds a more generic docker support

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -12,43 +12,63 @@
 ## can be added (i.e 'cmd/mybinary/Dockerfile'). Then, the provided
 ## Dockerfile will be used instead
 
-#
-# TODO: Translate to english
-# Esse módulo permite construir imagens docker e publicá-las.
-# O módulo provê um arquivo `Dockerfile` próprio, porém é possível
-# sobrescrever esse comportamento para binários específicos. Para
-# utilizar um `Dockerfile` próprio, basta criar um `Dockerfile`
-# dentro do diretório `cmd/<binário>`.
-#
-# Por exemplo, suponha 2 binários `api` e `worker` respectivamente
-# em `cmd/api` e `cmd/worker`. Caso exista o arquivo
-# `cmd/api/Dockerfile`, ao ser invocado o comando de construir a
-# imagems, por exemplo, com `docker-images`, a imagem do binaŕio
-# `api` usará `cmd/api/Dockerfile` mas a imagem do binário `worker`
-# usará `<stark-build>/modules/docker/Dockerfile`.
-
-
 ## Docker Module Variables
 
 ## List of images the will be built or published. It defaults
 ## to cmd/ directory content.
 DOCKER_IMAGES ?= $(shell ls ./cmd/ 2> /dev/null)
 
+# Deprecation notice for DOCKER_BASE_IMAGE
+ifdef DOCKER_BASE_IMAGE
+$(info [Stark Build] !!! Setting DOCKER_BASE_IMAGE is deprecated. Please set DOCKER_IMAGE_PREFIX instead.)
+endif
+
 ## Name of the project. This will compose the image's name like
 ## 'DOCKER_BASE_IMAGE/CMD:VERSION'. It defaults to the projets
-## diretory name.
+## directory name.
 DOCKER_BASE_IMAGE ?= $(GO_PROJECT)
 
-## GCR_BASE_URL is the googles registry prefix that will be
-## pre-appended at the image name.
-## You propably don't want to change this.
-GCR_BASE_URL ?= gcr.io/$(GCR_PROJECT)
+## Prefix of the image. This will be used to make the fullname of the
+## image locally as <DOCKER_IMAGE_PREFIX>/<CMD>:<VERSION>
+## and when publishing as <DOCKER_REMOTE>/<DOCKER_IMAGE_PREFIX>/<CMD>:<VERSION>
+## For compatibility it defaults to DOCKER_BASE_IMAGE, but it really should be
+## explicitly set.
+DOCKER_IMAGE_PREFIX ?= $(DOCKER_BASE_IMAGE)
+
+# Sets DOCKER_REMOTE ensuring backward compatibility.
+ifdef GCR_BASE_URL
+$(info [Stark Build] !!! Setting GCR_BASE_URL is deprecated. Please set DOCKER_REMOTE instead.)
+DOCKER_REMOTE ?= $(GCR_BASE_URL)
+else
+ifdef GCR_PROJECT
+$(info [Stark Build] !!! Setting GCR_PROJECT is deprecated. Please set DOCKER_REMOTE instead.)
+DOCKER_REMOTE ?= gcr.io/$(GCR_PROJECT)
+else
+## Prefix of the image when publishing to a remote repository. The full name of the image
+## is <DOCKER_REMOTE>/<DOCKER_IMAGE_PREFIX>/<CMD>:<VERSION>.
+DOCKER_REMOTE ?=
+endif
+endif
+
+## Google's registry prefix that will be pre-appended at the
+## image name like '<GCR_BASE_URL>/<DOCKER_BASE_IMAGE>/<CMD>:<VERSION>'.
+## Defaults to 'gcr.io/<GCR_PROJECT>'. See GCR_PROJECT.
+## Deprecated: Use DOCKER_IMAGE_PREFIX instead
+GCR_BASE_URL ?=
+
+## Is the project id for the google's container registry. See DOCKER_BASE_IMAGE
+## documentation.
+## Deprecated: Use DOCKER_IMAGE_PREFIX instead
+GCR_PROJECT ?=
+
 
 $(info [Stark Build] Initializing docker module...)
 $(info [Stark Build]   DOCKER_IMAGES = $(DOCKER_IMAGES))
-$(info [Stark Build]   DOCKER_BASE_IMAGE = $(DOCKER_BASE_IMAGE))
-$(info [Stark Build]   GCR_PROJECT = $(GCR_PROJECT))
-$(info [Stark Build]   GCR_BASE_URL = $(GCR_BASE_URL))
+$(info [Stark Build]   DOCKER_IMAGE_PREFIX = $(DOCKER_IMAGE_PREFIX))
+$(info [Stark Build]   DOCKER_REMOTE = $(DOCKER_REMOTE))
+$(info [Stark Build]   DOCKER_BASE_IMAGE [Deprecated] = $(DOCKER_BASE_IMAGE))
+$(info [Stark Build]   GCR_PROJECT [Deprecated] = $(GCR_PROJECT))
+$(info [Stark Build]   GCR_BASE_URL [Deprecated] = $(GCR_BASE_URL))
 
 ##
 ## Docker Module Targets
@@ -83,27 +103,20 @@ docker-publish: $(foreach img,$(DOCKER_IMAGES),docker-publish-version-$(img))
 docker-publish-latest: $(foreach img,$(DOCKER_IMAGES),docker-publish-latest-$(img))
 
 ## Publishes a single image using 'latest' as tag.
-docker-publish-latest-%: require-DOCKER_BASE_IMAGE
-ifndef GCR_PROJECT
-	$(error Please set GCR_PROJECT variable)
-endif
-	$(eval IMAGE = $(@:docker-publish-latest-%=$(DOCKER_BASE_IMAGE)/%))
+docker-publish-latest-%: require-VERSION require-DOCKER_IMAGE_PREFIX require-DOCKER_REMOTE
+	$(eval IMAGE = $(@:docker-publish-latest-%=$(DOCKER_IMAGE_PREFIX)/%))
 	$(eval LOCAL_TAG = $(IMAGE):$(VERSION))
-	$(eval REMOTE_TAG = $(GCR_BASE_URL)/$(IMAGE):latest)
+	$(eval REMOTE_TAG = $(DOCKER_REMOTE)/$(IMAGE):latest)
 	docker tag $(LOCAL_TAG) $(REMOTE_TAG)
 	docker push $(REMOTE_TAG)
 
 ## Publishes the generated images into Google's Registry using version as tag.
-docker-publish-version-%: require-DOCKER_BASE_IMAGE
-ifndef GCR_PROJECT
-	$(error Please set GCR_PROJECT variable)
-endif
-	$(eval IMAGE = $(@:docker-publish-version-%=$(DOCKER_BASE_IMAGE)/%))
+docker-publish-version-%: require-VERSION require-DOCKER_IMAGE_PREFIX require-DOCKER_REMOTE
+	$(eval IMAGE = $(@:docker-publish-version-%=$(DOCKER_IMAGE_PREFIX)/%))
 	$(eval LOCAL_TAG = $(IMAGE):$(VERSION))
-	$(eval REMOTE_TAG = $(GCR_BASE_URL)/$(LOCAL_TAG))
+	$(eval REMOTE_TAG = $(DOCKER_REMOTE)/$(LOCAL_TAG))
 	docker tag $(LOCAL_TAG) $(REMOTE_TAG)
 	docker push $(REMOTE_TAG)
-
 
 ## Removes all local images matching the same base name.
 .PHONY: docker-clean

--- a/modules/meta/help.awk
+++ b/modules/meta/help.awk
@@ -1,12 +1,12 @@
 {
-    if ($0 ~ /^.PHONY: [a-zA-Z\-_0-9%]+$/) {
+    if ($0 ~ /^.PHONY: [a-zA-Z\-_0-9%/]+$/) {
         helpCommand = substr($0, index($0, ":") + 2);
         if (helpMessage) {
             printf "\033[36m%-20s\033[0m %s\n",
                 helpCommand, helpMessage;
             helpMessage = "";
         }
-    } else if ($0 ~ /^[a-zA-Z\-_0-9.%]+:/) {
+    } else if ($0 ~ /^[a-zA-Z\-_0-9.%/]+:/) {
         helpCommand = substr($0, 0, index($0, ":") - 1);
         if (helpMessage) {
             printf "\033[36m%-20s\033[0m %s\n",


### PR DESCRIPTION
The previous docker module depends heavily on googles container registry. This commit introduces the DOCKER_IMAGE_PREFIX variable that is supposed to replace the previous behavior. Now images are named just as PREFIX/CMD.

Previous behavior can still be achieved by setting the GCP_PROJECT and DOCKER_BASE_IMAGE variables. This is expected to be removed in the future and whoever is calling the make target should set the expected prefix.

This commit also forces the images to always be created with the full name. So new the publish targets are not compatible with old images. This particular case is not supposed to happen and should be considered an error.

Fixed an error in help module that prevented targets with the slash character to be shown.