### PR TITLE
Fix use of grep on alpine

### DIFF
--- a/modules/golang/install-go-tool.sh
+++ b/modules/golang/install-go-tool.sh
@@ -8,7 +8,7 @@ bin=${2}
 importpath=${3}
 version=${4}
 
-if ! ${bin} -version | grep --quiet --no-messages --fixed-strings "${version}"; then
+if ! ${bin} -version | grep -q -s -F "${version}"; then
     echo "Installing $(basename "${bin}") version ${version}"
     GOBIN=${toolsdir} go install "${importpath}@${version}"
 else

--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -45,7 +45,7 @@ go-tools: $(foreach tool,$(GO_TOOLS),$(GO_TOOLS_DIR)/$(tool))
 # See https://goswagger.io/install.html
 .PHONY: $(GO_TOOLS_DIR)/swagger
 $(GO_TOOLS_DIR)/swagger: | $(GO_TOOLS_DIR)
-	@ if ! $@ version | grep --quiet --no-messages --fixed-strings "$(GO_SWAGGER_VERSION)"; then \
+	@ if ! $@ version | grep -q -s -F "$(GO_SWAGGER_VERSION)"; then \
 		echo "Installing $@ version $(GO_TOOLS_SWAGGER_VERSION)"; \
 		curl -o $@ -L'#' "https://github.com/go-swagger/go-swagger/releases/download/$(GO_TOOLS_SWAGGER_VERSION)/swagger_$(GO_TOOLS_OS)_$(GO_TOOLS_ARCH)"; \
 		chmod +x $@; \
@@ -57,7 +57,7 @@ $(GO_TOOLS_DIR)/swagger: | $(GO_TOOLS_DIR)
 # See: https://golangci-lint.run/usage/install/
 .PHONY: $(GO_TOOLS_DIR)/golangci-lint
 $(GO_TOOLS_DIR)/golangci-lint: | $(GO_TOOLS_DIR)
-	@ if ! $@ --version | grep --quiet --no-messages --fixed-strings "$(GO_TOOLS_GOLANGCI_VERSION)"; then \
+	@ if ! $@ --version | grep -q -s -F "$(GO_TOOLS_GOLANGCI_VERSION)"; then \
 		echo "Installing $@ version $(GO_TOOLS_GOLANGCI_VERSION)"; \
 		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 			sh -s -- -b "$(GO_TOOLS_DIR)" "v$(GO_TOOLS_GOLANGCI_VERSION)"; \


### PR DESCRIPTION
When running the stark-build inside an alpine container the error "grep: unrecognized option: quiet" will pop when the go module is checking the required tools.

This happens because the script uses grep with the "--quiet" flag but on alpine the grep don't allow for long flags and the short "-q" should be used.

This commit changes all long flags used in grep commands for it's short counterpart so that it is compatible with typical grep and the BusyBox's grep that is used inside alpine.