### PR TITLE
Bump go-tools

### DIFF
--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -15,11 +15,11 @@ GO_TOOLS_SWAGGER_VERSION ?= v0.30.4
 
 ## Selects golangci-lint version.
 ## https://github.com/golangci/golangci-lint/releases
-GO_TOOLS_GOLANGCI_VERSION ?= 1.50.1
+GO_TOOLS_GOLANGCI_VERSION ?= 1.51.0
 
 ## Selects goose version.
 ## https://github.com/pressly/goose/releases
-GO_TOOLS_GOOSE_VERSION ?= v3.8.0
+GO_TOOLS_GOOSE_VERSION ?= v3.9.0
 
 ## Selects go-junit-report version.
 ## https://github.com/jstemmer/go-junit-report/releases


### PR DESCRIPTION
golangci-lint bumped to 1.51.0. The first release to support the new go 1.20.

goose bumped to 3.9.0.