### PR TITLE
Improve 'stark-build-update' command

### DIFF
--- a/modules/meta/Makefile
+++ b/modules/meta/Makefile
@@ -24,7 +24,7 @@ print-%: require-%
 ## Updates the Stark Build System to the latest version.
 .PHONY: stark-build-update
 stark-build-update:
-	cd $(STARK_BUILD_DIR) && git pull origin main
+	cd $(STARK_BUILD_DIR) && git fetch --prune --prune-tags && git reset --hard origin/main
 
 ## Prints this help.
 .PHONY: help


### PR DESCRIPTION
In systems which git does note have an explicit configuration of pull strategy for branches with differences, the command 'stark-build-update' may fail. This commit solves the issue by explicitly forcing the stark build submodule to back to main branch, and then update it.