### PR TITLE
Fixes swagger tool

### DIFF
--- a/modules/golang/install-go-tool.sh
+++ b/modules/golang/install-go-tool.sh
@@ -7,8 +7,9 @@ toolsdir=${1}
 bin=${2}
 importpath=${3}
 version=${4}
+version_flag=${5}
 
-if ! ${bin} -version | grep -q -s -F "${version}"; then
+if ! ${bin} "${version_flag}" | grep -q -s -F "${version}"; then
     echo "Installing $(basename "${bin}") version ${version}"
     GOBIN=${toolsdir} go install "${importpath}@${version}"
 else

--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -45,30 +45,24 @@ go-tools: $(foreach tool,$(GO_TOOLS),$(GO_TOOLS_DIR)/$(tool))
 # See https://goswagger.io/install.html
 .PHONY: $(GO_TOOLS_DIR)/swagger
 $(GO_TOOLS_DIR)/swagger: | $(GO_TOOLS_DIR)
-	@ if ! $@ version | grep -q -s -F "$(GO_SWAGGER_VERSION)"; then \
-		echo "Installing $@ version $(GO_TOOLS_SWAGGER_VERSION)"; \
-		curl -o $@ -L'#' "https://github.com/go-swagger/go-swagger/releases/download/$(GO_TOOLS_SWAGGER_VERSION)/swagger_$(GO_TOOLS_OS)_$(GO_TOOLS_ARCH)"; \
-		chmod +x $@; \
-	else \
-		echo "$@ already at version $(GO_TOOLS_SWAGGER_VERSION)"; \
-	fi
+	@$(STARK_BUILD_DIR)modules/golang/install-go-tool.sh $(GO_TOOLS_DIR) $@ github.com/go-swagger/go-swagger/cmd/swagger $(GO_TOOLS_SWAGGER_VERSION) version
 
 # Installation script is preferred over `go install`.
 # See: https://golangci-lint.run/usage/install/
 .PHONY: $(GO_TOOLS_DIR)/golangci-lint
 $(GO_TOOLS_DIR)/golangci-lint: | $(GO_TOOLS_DIR)
 	@ if ! $@ --version | grep -q -s -F "$(GO_TOOLS_GOLANGCI_VERSION)"; then \
-		echo "Installing $@ version $(GO_TOOLS_GOLANGCI_VERSION)"; \
+		echo "Installing $(notdir $@) version $(GO_TOOLS_GOLANGCI_VERSION)"; \
 		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
 			sh -s -- -b "$(GO_TOOLS_DIR)" "v$(GO_TOOLS_GOLANGCI_VERSION)"; \
 	else \
-		echo "$@ already at version $(GO_TOOLS_GOLANGCI_VERSION)"; \
+		echo "$(notdir $@) already at version $(GO_TOOLS_GOLANGCI_VERSION)"; \
 	fi
 
 .PHONY: $(GO_TOOLS_DIR)/goose
 $(GO_TOOLS_DIR)/goose: | $(GO_TOOLS_DIR)
-	$(STARK_BUILD_DIR)modules/golang/install-go-tool.sh $(GO_TOOLS_DIR) $@ github.com/pressly/goose/v3/cmd/goose $(GO_TOOLS_GOOSE_VERSION)
+	@$(STARK_BUILD_DIR)modules/golang/install-go-tool.sh $(GO_TOOLS_DIR) $@ github.com/pressly/goose/v3/cmd/goose $(GO_TOOLS_GOOSE_VERSION) -version
 
 .PHONY: $(GO_TOOLS_DIR)/go-junit-report
 $(GO_TOOLS_DIR)/go-junit-report:
-	$(STARK_BUILD_DIR)modules/golang/install-go-tool.sh $(GO_TOOLS_DIR) $@ github.com/jstemmer/go-junit-report/v2 $(GO_TOOLS_XUNIT_VERSION)
+	@$(STARK_BUILD_DIR)modules/golang/install-go-tool.sh $(GO_TOOLS_DIR) $@ github.com/jstemmer/go-junit-report/v2 $(GO_TOOLS_XUNIT_VERSION) -version


### PR DESCRIPTION
The tool was broken in two different ways:

1. A variable was named wrongly causing the update command to never update an existing tool.
2. The swagger binary is not working correctly with new versions of go, generating an incomplete spec.

The variable was fixes and using go-get to install swagger seems to fix the problem with the spec.

The install script had to be updated to support the swagger binary. It differs from previous binaries because it uses 'version' instead of '-version' for retrieving the current binary version. Now this flag if configurable and the Makefile passes the correct form for each tool.

There is already an open issue for this problem:

https://github.com/go-swagger/go-swagger/issues/2897