### PR TITLE
Bumps golangci-lint to 1.51.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following snippet to your `Makefile`:
 ## Initializes or syncronizes stark build directory.
 .PHONY: stark-build-sync
 stark-build-sync:
-	git submodule update --init --recursive --depth=1 tooling/stark-build/
+	git submodule update --init --recursive tooling/stark-build/
 
 -include tooling/stark-build/Makefile
 ```
@@ -51,7 +51,7 @@ GO_SWAGGER_GEN := API
 # Enables stark-build
 .PHONY: stark-build-sync
 stark-build-sync:
-	git submodule update --init --recursive --depth=1 tooling/stark-build/
+	git submodule update --init --recursive tooling/stark-build/
 
 -include tooling/stark-build/Makefile
 

--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -15,7 +15,7 @@ GO_TOOLS_SWAGGER_VERSION ?= v0.30.4
 
 ## Selects golangci-lint version.
 ## https://github.com/golangci/golangci-lint/releases
-GO_TOOLS_GOLANGCI_VERSION ?= 1.51.1
+GO_TOOLS_GOLANGCI_VERSION ?= 1.51.2
 
 ## Selects goose version.
 ## https://github.com/pressly/goose/releases


### PR DESCRIPTION
Adjust README to remote depth and be consistent with the update target. stark-build don't use shallow clone anymore.