### PR TITLE
The go tools have been updated to newer versions:

### DIFF
--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -15,11 +15,11 @@ GO_TOOLS_SWAGGER_VERSION ?= v0.30.5
 
 ## Selects golangci-lint version.
 ## https://github.com/golangci/golangci-lint/releases
-GO_TOOLS_GOLANGCI_VERSION ?= 1.55.2
+GO_TOOLS_GOLANGCI_VERSION ?= 1.56.1
 
 ## Selects goose version.
 ## https://github.com/pressly/goose/releases
-GO_TOOLS_GOOSE_VERSION ?= v3.16.0
+GO_TOOLS_GOOSE_VERSION ?= v3.18.0
 
 ## Selects go-junit-report version.
 ## https://github.com/jstemmer/go-junit-report/releases


### PR DESCRIPTION
* golangci-lint: v1.55.2 to v1.56.1

* goose: v3.16.0 to v3.18.0