### PR TITLE
Improve coverage command

### DIFF
--- a/modules/golang/Makefile
+++ b/modules/golang/Makefile
@@ -174,7 +174,7 @@ PHONY: .cover/cover.out
 	@rm -rf .cover
 	@mkdir .cover
 	@for SUBPKG in $(shell $(GO) list -mod=vendor ./...) ; do \
-		FILE=$${SUBPKG##$(PKG)/} ; $(GO_TEST) \
+		FILE=$${SUBPKG##$(PKG)/} ; GOEXPERIMENT=nocoverageredesign $(GO_TEST) \
 		-covermode="$(GO_COVER_MODE)" \
 		-coverprofile=".cover/$${FILE////-}.cover" \
 		"$$SUBPKG" | tee -a .cover/stdout.txt || exit 1; \


### PR DESCRIPTION
The version 1.22 of Go changed the way test coverage is calculated. Now, instead of ignoring files that do not have tests, they are considered, reducing the coverage percentage.

GOEXPERIMENT=nocoverageredesign was added to the command that calculates the coverage to revert to the old behavior.