### PR TITLE
Reduces verbosity when executing targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ starkbuild_makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 STARK_BUILD_DIR := $(dir $(starkbuild_makefile_path))
 
 main_makefile_path := $(abspath $(firstword $(MAKEFILE_LIST)))
-# This is the directory of the project includind this makefile.
+# This is the directory of the project including this Makefile.
 PROJECT_DIR := $(dir $(main_makefile_path))
 
-## Cache directory where modulos may store temporary files.
+## Cache directory where modules may store temporary files.
 STARK_BUILD_CACHE_DIR ?= $(PROJECT_DIR)/.cache/
 
 ifeq ($(VERSION),)
@@ -42,13 +42,17 @@ endif
 # do bash (arch linux, for example) and in others 'sh' is an alias to 'dash' (ubuntu).
 SHELL := /bin/bash
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing Stark Build System...)
 $(info [Stark Build]   STARK_BUILD_DIR = $(STARK_BUILD_DIR))
 $(info [Stark Build]   STARK_BUILD_MODULES = $(STARK_BUILD_MODULES))
 $(info [Stark Build]   STARK_BUILD_CACHE_DIR = $(STARK_BUILD_CACHE_DIR))
 $(info [Stark Build]   PROJECT_DIR = $(PROJECT_DIR))
 $(info [Stark Build]   VERSION = $(VERSION))
+endif
 
 include $(foreach MOD,$(STARK_BUILD_MODULES),$(STARK_BUILD_DIR)/modules/$(MOD)/Makefile)
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Stark Build System initialized. Have a nice day! )
+endif

--- a/modules/cloudfunctions/Makefile
+++ b/modules/cloudfunctions/Makefile
@@ -17,7 +17,9 @@ CLOUDFUNCTIONS_SRC_DIR ?= functions/
 # Functions to be build automatically
 CLOUDFUNCTIONS ?= $(shell ls $(CLOUDFUNCTIONS_SRC_DIR) 2>/dev/null)
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing CloudFunctions module...)
+endif
 
 ## Targets
 
@@ -102,4 +104,6 @@ cloudfunctions-deploy:
 cloudfunctions-clean:
 	rm -rf $(CLOUDFUNCTIONS_BIN_DIR)*.zip
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] CloudFunctions module loaded.)
+endif

--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -61,7 +61,7 @@ GCR_BASE_URL ?=
 ## Deprecated: Use DOCKER_IMAGE_PREFIX instead
 GCR_PROJECT ?=
 
-
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing docker module...)
 $(info [Stark Build]   DOCKER_IMAGES = $(DOCKER_IMAGES))
 $(info [Stark Build]   DOCKER_IMAGE_PREFIX = $(DOCKER_IMAGE_PREFIX))
@@ -69,6 +69,7 @@ $(info [Stark Build]   DOCKER_REMOTE = $(DOCKER_REMOTE))
 $(info [Stark Build]   DOCKER_BASE_IMAGE [Deprecated] = $(DOCKER_BASE_IMAGE))
 $(info [Stark Build]   GCR_PROJECT [Deprecated] = $(GCR_PROJECT))
 $(info [Stark Build]   GCR_BASE_URL [Deprecated] = $(GCR_BASE_URL))
+endif
 
 ##
 ## Docker Module Targets
@@ -123,4 +124,6 @@ docker-publish-version-%: require-VERSION require-DOCKER_IMAGE_PREFIX require-DO
 docker-clean:
 	docker images -a | grep $(DOCKER_IMAGE_PREFIX) | awk '{print $$3}' | xargs --no-run-if-empty docker rmi
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Docker module initialized.)
+endif

--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -5,7 +5,9 @@
 ##
 ## This module provides git integration
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing git module...)
+endif
 
 ## List of targets that will run on pre-commit
 ## Default: go-tools vendor git-ensure-clean go-lint go-tests go-ensure-coverage
@@ -41,4 +43,6 @@ git-execute-hook-precommit: $(GIT_HOOKS_PRECOMMIT)
 .PHONY: git-execute-hook-postmerge
 git-execute-hook-postmerge: $(GIT_HOOKS_POSTMERGE)
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Git module loaded.)
+endif

--- a/modules/golang/Makefile
+++ b/modules/golang/Makefile
@@ -78,12 +78,14 @@ GO_COVER_MODE ?= set
 GO_LIB_DIR ?= lib
 GO_LIB_OUTPUT_DIR ?= out/lib
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing golang module...)
 $(info [Stark Build]   GOVERSION = $(shell $(GO) env GOVERSION))
 $(info [Stark Build]   GO_BINS = $(GO_BINS))
 $(info [Stark Build]   COMPRESS_ENABLED = $(COMPRESS_ENABLED))
 $(info [Stark Build]   GO_MINIMUM_COVERAGE = $(GO_MINIMUM_COVERAGE))
 $(info [Stark Build]   GO_LIBS = $(GO_LIBS))
+endif
 
 ## Compilation targets
 
@@ -233,4 +235,6 @@ go-update-vendor:
 include $(STARK_BUILD_DIR)/modules/golang/tools.mk
 include $(STARK_BUILD_DIR)/modules/golang/swagger.mk
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Golang module loaded.)
+endif

--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -25,8 +25,10 @@ GO_TOOLS_GOOSE_VERSION ?= v3.19.2
 ## https://github.com/jstemmer/go-junit-report/releases
 GO_TOOLS_XUNIT_VERSION ?= v2.1.0
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build]   GO_TOOLS = $(GO_TOOLS))
 $(info [Stark Build]   GO_TOOLS_DIR = $(GO_TOOLS_DIR))
+endif
 
 $(GO_TOOLS_DIR):
 	mkdir -p $(GO_TOOLS_DIR)

--- a/modules/meta/Makefile
+++ b/modules/meta/Makefile
@@ -5,7 +5,9 @@
 ## This module handles stuff related to the Stark Build itself
 ## or provides utility targets.
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing meta module...)
+endif
 
 # This target was created inspired by this stackoverflow question:
 # https://stackoverflow.com/questions/4728810/makefile-variable-as-prerequisite/35845931
@@ -33,4 +35,6 @@ help:
 
 .DEFAULT_GOAL := help
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Meta module initialized.)
+endif

--- a/modules/slack/Makefile
+++ b/modules/slack/Makefile
@@ -4,7 +4,9 @@
 ##
 ## This module provides slack integration
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Initializing slack module...)
+endif
 
 
 # For this to work you must write the desired message in a json file and
@@ -23,12 +25,14 @@ SLACK_GIT_LOG ?= $(shell git log -1 | sed -e ':a' -e 'N' -e '$$!ba' -e 's/\n/\\n
 ## initially but it's expected that each project will have it's own
 ## message.
 ## Before the message is sent the json is altered using envsubst
-## so we have minimal templating capabilities.
+## so we have minimal template capabilities.
 ## The variable SLACK_GIT_LOG is passed as GIT_LOG to the envsubst.
 SLACK_MESSAGE ?= $(STARK_BUILD_DIR)modules/slack/message.json
 
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build]   SLACK_MESSAGE = $(SLACK_MESSAGE))
 $(info [Stark Build]   SLACK_WEBHOOK_URL = $(SLACK_WEBHOOK_URL))
+endif
 
 ## Posts a message to slack.
 .PHONY: slack-send-message
@@ -38,4 +42,7 @@ slack-send-message: require-SLACK_MESSAGE require-SLACK_WEBHOOK_URL
 		curl \
 			--header 'Content-type: application/json' \
 			--data-binary @- $(SLACK_WEBHOOK_URL)
+
+ifeq ($(STARK_BUILD_DEBUG),true)
 $(info [Stark Build] Slack module loaded.)
+endif


### PR DESCRIPTION
The initialization of stark-build was printing too much information and this clobber the terminal's readability.

Now the initialization information and variables are not printed unless STARK_BUILD_DEBUG=true is set.