### PR TITLE
chore: update GolangCI to support Go 1.25

### DIFF
--- a/modules/golang/tools.mk
+++ b/modules/golang/tools.mk
@@ -15,11 +15,11 @@ GO_TOOLS_SWAGGER_VERSION ?= v0.32.3
 
 ## Selects golangci-lint version.
 ## https://github.com/golangci/golangci-lint/releases
-GO_TOOLS_GOLANGCI_VERSION ?= 2.3.0
+GO_TOOLS_GOLANGCI_VERSION ?= 2.4.0
 
 ## Selects goose version.
 ## https://github.com/pressly/goose/releases
-GO_TOOLS_GOOSE_VERSION ?= v3.24.3
+GO_TOOLS_GOOSE_VERSION ?= v3.25.0
 
 ## Selects go-junit-report version.
 ## https://github.com/jstemmer/go-junit-report/releases


### PR DESCRIPTION
The new GolangCI version adds support for Go 1.25
Goose also updated.